### PR TITLE
fix: treat bad tokens in auth file as token not found

### DIFF
--- a/src/KapetaAPI.ts
+++ b/src/KapetaAPI.ts
@@ -145,9 +145,13 @@ export class KapetaAPI {
     }
 
     private readToken() {
-        if (FS.existsSync(this.getTokenPath())) {
-            this._authInfo = JSON.parse(FS.readFileSync(this.getTokenPath()).toString());
-            this._userInfo = jwt_decode(this._authInfo!.access_token!);
+        try {
+            if (FS.existsSync(this.getTokenPath())) {
+                this._authInfo = JSON.parse(FS.readFileSync(this.getTokenPath()).toString());
+                this._userInfo = jwt_decode(this._authInfo!.access_token!);
+            }
+        } catch (e) {
+            console.log(`Failed to read token at ${this.getTokenPath()}. Got ${e}`);
         }
     }
 


### PR DESCRIPTION
Changing the database IDs seems to have corrupted some tokens, and the SDK does not handle that gracefully.
We need to guard against bad auth payloads to ensure that the app can recover if that happens.
