### PR TITLE
fix: handle non-JSON in error responses

### DIFF
--- a/src/KapetaAPI.ts
+++ b/src/KapetaAPI.ts
@@ -412,9 +412,10 @@ export class KapetaAPI {
                         return;
                     }
 
-                    const errorBody = responseBody
-                        ? JSON.parse(responseBody)
-                        : { error: 'Not found', status: response.statusCode };
+                    let errorBody = { error: 'Unknown error', status: response.statusCode };
+                    try {
+                        errorBody = JSON.parse(responseBody);
+                    } catch (e) {}
 
                     const err = new APIError(errorBody.error || 'Unknown error');
                     err.status = errorBody.status ?? response.statusCode;


### PR DESCRIPTION
This should prevent the request function from throwing an unhandled exception, when trying to parse the error payload.
Unhandled exception is due to the request callback being async, not happening "inside" the promise even though the code makes it seem that way.