### PR TITLE
fix: remove cross-fetch to remove punycode issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
             "license": "MIT",
             "dependencies": {
                 "@kapeta/local-cluster-config": "<2",
-                "cross-fetch": "^4.0.0",
                 "jwt-decode": "^3.1.2"
             },
             "devDependencies": {
@@ -89,14 +88,6 @@
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
         },
-        "node_modules/cross-fetch": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
-            "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
-            "dependencies": {
-                "node-fetch": "^2.6.12"
-            }
-        },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -151,25 +142,6 @@
                 "node": "*"
             }
         },
-        "node_modules/node-fetch": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-            "dependencies": {
-                "whatwg-url": "^5.0.0"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -201,11 +173,6 @@
                 "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
-        "node_modules/tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-        },
         "node_modules/typescript": {
             "version": "5.4.5",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
@@ -224,20 +191,6 @@
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
             "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
             "dev": true
-        },
-        "node_modules/webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-        },
-        "node_modules/whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-            "dependencies": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
-            }
         },
         "node_modules/wrappy": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     },
     "dependencies": {
         "@kapeta/local-cluster-config": "<2",
-        "cross-fetch": "^4.0.0",
         "jwt-decode": "^3.1.2"
     },
     "devDependencies": {

--- a/src/KapetaAPI.ts
+++ b/src/KapetaAPI.ts
@@ -6,7 +6,6 @@
 import * as FS from 'fs';
 import jwt_decode from 'jwt-decode';
 import ClusterConfiguration from '@kapeta/local-cluster-config';
-import { fetch } from 'cross-fetch';
 
 const AUTH_TOKEN = ClusterConfiguration.getAuthenticationPath();
 const DEFAULT_CLIENT_ID = '63bbeafc39388b47691111ae';


### PR DESCRIPTION
Turns out cross-fetch is pulling in an old node-fetch, that pulls in a very old whatwg-url, that still relies on the deprecated module. 

We don't actually need `cross-fetch`, let's just use the global in all envs.

```
[DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
[...]
./node_modules/@kapeta/nodejs-api-client/node_modules/whatwg-url/lib/url-state-machine.js:2:18
```

```
$ npm ls whatwg-url
└─┬ cross-fetch@4.0.0
  └─┬ node-fetch@2.7.0
    └── whatwg-url@5.0.0
```